### PR TITLE
feat: make TypeScript 5 available to plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /yarn.lock
 node_modules
 oclif.manifest.json
+*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "playwright": "^1.38.0",
         "prettier": "^3.0.0",
         "rimraf": "^5.0.1",
-        "shelljs-live": "^0.0.5"
+        "shelljs-live": "^0.0.5",
+        "typescript": "^5.2.2"
       },
       "bin": {
         "swup": "bin/run.js"
@@ -45,8 +46,7 @@
         "oclif": "^3.16.0",
         "shx": "^0.3.4",
         "ts-node": "^10.9.1",
-        "tslib": "^2.6.2",
-        "typescript": "^5.2.2"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "playwright": "^1.38.0",
     "prettier": "^3.0.0",
     "rimraf": "^5.0.1",
-    "shelljs-live": "^0.0.5"
+    "shelljs-live": "^0.0.5",
+    "typescript": "^5.2.2"
   },
   "devDependencies": {
     "@oclif/test": "^2.5.5",
@@ -56,8 +57,7 @@
     "oclif": "^3.16.0",
     "shx": "^0.3.4",
     "ts-node": "^10.9.1",
-    "tslib": "^2.6.2",
-    "typescript": "^5.2.2"
+    "tslib": "^2.6.2"
   },
   "oclif": {
     "bin": "swup",


### PR DESCRIPTION
**Description**

Tested locally using `npm pack` and this inside my plugin:

```json
{
  "devDependencies": {
    "@swup/cli": "file:../cli/swup-cli-5.0.0.tgz"
  },
}
```
After a fresh install, I got typescript 5 in my plugin: 

![image](https://github.com/swup/cli/assets/869813/e0b50e1b-3200-49ff-80c0-5c49faab2120)

**Questions**

- @daun, does this bring us back to square one, where typescript could be installed unintentionally? I guess not, since `@swup/cli` is only a `devDependency` of our plugins, right?

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [] ~The code was linted before pushing (`npm run lint`)~ This looks like it needs it's own PR 💥
